### PR TITLE
Remove feeInKind from transfers and tradeWithLLMFees function

### DIFF
--- a/script/TestTrading.s.sol
+++ b/script/TestTrading.s.sol
@@ -55,17 +55,18 @@ contract TestTrading is Script {
         console.log("\n=== AFTER TRADE 1 ===");
         _displayBalances(llmBits, tokenAI, testAccount1, testAccount2, gptAiCourseId, gptWeb3CourseId);
         
-        // Test 2: Trade with in-kind fees (LLMBits tokens)
-        console.log("\n=== TEST 2: TRADE WITH IN-KIND FEES ===");
+        // Test 2: Second trade with native fees only
+        console.log("\n=== TEST 2: SECOND TRADE WITH NATIVE FEES ===");
         console.log("Account 2 trades 30 Web3 tokens for 50 AI Course tokens from Account 1");
-        console.log("In-kind fees: 5 AI Course tokens from Account 1, 3 Web3 tokens from Account 2");
+        console.log("Native fees: 3 tTAI from Account 2, 5 tTAI from Account 1");
         
-        llmBits.tradeWithLLMFees(
+        llmBits.tradeWithNativeFees(
             testAccount2, testAccount1,
             gptWeb3CourseId, 30,       // Account 2 gives 30 Web3 tokens
             gptAiCourseId, 50,         // Account 1 gives 50 AI course tokens
-            3,                         // 3 Web3 tokens as fee from Account 2
-            5                          // 5 AI course tokens as fee from Account 1
+            0,                         // No match mask
+            3 * 10**18,               // 3 tTAI fee from Account 2
+            5 * 10**18                // 5 tTAI fee from Account 1
         );
         
         console.log("\n=== AFTER TRADE 2 ===");
@@ -77,8 +78,6 @@ contract TestTrading is Script {
         address treasury = llmBits.treasury();
         console.log("\n=== TREASURY EARNINGS ===");
         console.log("Treasury TokenAI Balance:", tokenAI.balanceOf(treasury) / 10**18, "tTAI");
-        console.log("Treasury GPT-4 AI Course tokens:", llmBits.balanceOf(treasury, gptAiCourseId));
-        console.log("Treasury GPT-4 Web3 Course tokens:", llmBits.balanceOf(treasury, gptWeb3CourseId));
     }
     
     function _displayBalances(

--- a/script/TestTransfers.s.sol
+++ b/script/TestTransfers.s.sol
@@ -47,25 +47,23 @@ contract TestTransfers is Script {
             testAccount2,
             gptAiCourseId,
             50,              // amount
-            5 * 10**18,      // 5 tTAI native fee
-            0                // no in-kind fee
+            5 * 10**18       // 5 tTAI native fee
         );
         
         console.log("\n=== AFTER TRANSFER 1 ===");
         _displayBalances(llmBits, tokenAI, testAccount1, testAccount2, gptAiCourseId, claudeMlCourseId);
         
-        // Test 2: Transfer with in-kind fee
-        console.log("\n=== TEST 2: TRANSFER WITH IN-KIND FEE ===");
+        // Test 2: Transfer with native fee only
+        console.log("\n=== TEST 2: TRANSFER WITH NATIVE FEE ===");
         console.log("Transfer 25 Claude ML tokens from Account 1 to Account 2");
-        console.log("Fee: 2 Claude ML tokens");
+        console.log("Fee: 2 tTAI");
         
         llmBits.transfer(
             testAccount1,
             testAccount2,
             claudeMlCourseId,
             25,              // amount
-            0,               // no native fee
-            2                // 2 tokens in-kind fee
+            2 * 10**18       // 2 tTAI native fee
         );
         
         console.log("\n=== AFTER TRANSFER 2 ===");
@@ -87,17 +85,12 @@ contract TestTransfers is Script {
         feesNative[0] = 2 * 10**18; // 2 tTAI fee for Account 2 transfer
         feesNative[1] = 1 * 10**18; // 1 tTAI fee for deployer transfer
         
-        uint256[] memory feesInKind = new uint256[](2);
-        feesInKind[0] = 0;
-        feesInKind[1] = 0;
-        
         llmBits.batchTransfer(
             testAccount1,
             recipients,
             gptAiCourseId,
             amounts,
-            feesNative,
-            feesInKind
+            feesNative
         );
         
         console.log("\n=== AFTER BATCH TRANSFER ===");
@@ -113,7 +106,6 @@ contract TestTransfers is Script {
             testAccount1,
             nonTradableId,
             10,
-            0,
             0
         ) {
             console.log("ERROR: Non-tradable transfer succeeded (should have failed)");
@@ -133,8 +125,7 @@ contract TestTransfers is Script {
             testAccount1,    // to Account 1
             instructorPoolId,
             50,              // amount
-            0,               // no native fee
-            0                // no in-kind fee
+            0                // no native fee
         );
         
         console.log("Transferred 50 instructor pool tokens to Account 1");


### PR DESCRIPTION
- Remove feeInKind parameter from transfer() and batchTransfer() functions
- Remove tradeWithLLMFees() function completely
- Remove FeeAppliedInKind event
- Update all tests to use native fees only
- Simplify fee structure to only support TokenAI native token fees

🤖 Generated with [Claude Code](https://claude.ai/code)